### PR TITLE
feat: skip prompt if instructed or in preview mode

### DIFF
--- a/audiobook_generator/config/general_config.py
+++ b/audiobook_generator/config/general_config.py
@@ -6,6 +6,7 @@ class GeneralConfig:
         self.preview = args.preview
         self.output_text = args.output_text
         self.log = args.log
+        self.no_prompt = args.no_prompt
 
         # Book parser specific arguments
         self.newline_mode = args.newline_mode

--- a/audiobook_generator/core/audiobook_generator.py
+++ b/audiobook_generator/core/audiobook_generator.py
@@ -9,8 +9,7 @@ from audiobook_generator.tts_providers.base_tts_provider import get_tts_provider
 logger = logging.getLogger(__name__)
 
 
-def confirm_conversion(price):
-    print(f"Estimate book voiceover would cost you roughly: ${price:.2f}")
+def confirm_conversion():
     print("Do you want to continue? (y/n)")
     answer = input()
     if answer.lower() != "y":
@@ -67,7 +66,15 @@ class AudiobookGenerator:
             total_characters = get_total_chars(chapters)
             logger.info(f"✨ Total characters in selected book: {total_characters} ✨")
             rough_price = tts_provider.estimate_cost(total_characters)
-            confirm_conversion(rough_price)
+            print(f"Estimate book voiceover would cost you roughly: ${rough_price:.2f}\n")
+
+            # Prompt user to continue if not in preview mode
+            if self.config.no_prompt:
+                logger.info(f"Skipping prompt as passed parameter no_prompt")
+            if self.config.preview:
+                logger.info(f"Skipping prompt as in preview mode")
+            else:
+                confirm_conversion()
 
             # Loop through each chapter and convert it to speech using the provided TTS provider
             for idx, (title, text) in enumerate(chapters, start=1):

--- a/main.py
+++ b/main.py
@@ -35,6 +35,11 @@ def handle_args():
         help="Enable preview mode. In preview mode, the script will not convert the text to speech. Instead, it will print the chapter index, titles, and character counts.",
     )
     parser.add_argument(
+        "--no_prompt",
+        action="store_true",
+        help="Don't ask the user if they wish to continue after estimating the cloud cost for TTS. Useful for scripting.",
+    )
+    parser.add_argument(
         "--language",
         default="en-US",
         help="Language for the text-to-speech service (default: en-US). For Azure TTS (--tts=azure), check https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support?tabs=tts#text-to-speech for supported languages. For OpenAI TTS (--tts=openai), their API detects the language automatically. But setting this will also help on splitting the text into chunks with different strategies in this tool, especially for Chinese characters. For Chinese books, use zh-CN, zh-TW, or zh-HK.",


### PR DESCRIPTION
Addresses Feature request in issue #35 

I tried to match the existing code as much as possible. 

I did refactor the prompt a little as I think it would be still good to estimate cost and display that, even in preview mode.