### PR TITLE
Fixing bug in if elif else block from previous PR

### DIFF
--- a/audiobook_generator/core/audiobook_generator.py
+++ b/audiobook_generator/core/audiobook_generator.py
@@ -71,7 +71,7 @@ class AudiobookGenerator:
             # Prompt user to continue if not in preview mode
             if self.config.no_prompt:
                 logger.info(f"Skipping prompt as passed parameter no_prompt")
-            if self.config.preview:
+            elif self.config.preview:
                 logger.info(f"Skipping prompt as in preview mode")
             else:
                 confirm_conversion()


### PR DESCRIPTION
small bug pointed out by timz06

> On line 74, it should be "elif self.config.preview:" instead of only "if self.config.preview:" for it to become a multiple if-elif-else logic. Because when I include the no_prompt argument, it still does the confirm_conversion() function.
