### PR TITLE
Add optional arg to use a temporary directory when converting files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ venv/
 .run/
 
 # Temporary files
+tmp/
 *.tmp
 *.swp
 *.swo

--- a/audiobook_generator/config/general_config.py
+++ b/audiobook_generator/config/general_config.py
@@ -2,7 +2,7 @@ class GeneralConfig:
     def __init__(self, args):
         # General arguments
         self.input_file = args.input_file
-        self.temp_dir = args.temp_dir
+        self.temp_dir = "tmp" if args.use_temp_dir else None
         self.output_folder = args.output_folder
         self.preview = args.preview
         self.output_text = args.output_text

--- a/audiobook_generator/config/general_config.py
+++ b/audiobook_generator/config/general_config.py
@@ -2,6 +2,7 @@ class GeneralConfig:
     def __init__(self, args):
         # General arguments
         self.input_file = args.input_file
+        self.temp_dir = args.temp_dir
         self.output_folder = args.output_folder
         self.preview = args.preview
         self.output_text = args.output_text

--- a/audiobook_generator/core/audiobook_generator.py
+++ b/audiobook_generator/core/audiobook_generator.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shutil
 
 from audiobook_generator.book_parsers.base_book_parser import get_book_parser
 from audiobook_generator.config.general_config import GeneralConfig
@@ -27,16 +28,50 @@ def get_total_chars(chapters):
 class AudiobookGenerator:
     def __init__(self, config: GeneralConfig):
         self.config = config
+        self.temp_folder = None
+        self.working_dir = None
 
     def __str__(self) -> str:
         return f"{self.config}"
+
+    def setup_directories(self, book_title):
+        """Setup output and temp directories"""
+        os.makedirs(self.config.output_folder, exist_ok=True)
+        
+        if self.config.temp_dir:
+            # Create temp dir if it doesn't exist
+            os.makedirs(self.config.temp_dir, exist_ok=True)
+            # Create book-specific subfolder in temp dir
+            safe_title = "".join(c for c in book_title if c.isalnum() or c in (' ', '-', '_')).rstrip()
+            self.temp_folder = os.path.join(self.config.temp_dir, safe_title)
+            os.makedirs(self.temp_folder, exist_ok=True)
+            self.working_dir = self.temp_folder
+        else:
+            self.working_dir = self.config.output_folder
+
+    def cleanup_temp_folder(self):
+        """Clean up temporary directory after successful move"""
+        if self.temp_folder and os.path.exists(self.temp_folder):
+            shutil.rmtree(self.temp_folder)
+            logger.info(f"Cleaned up temporary directory: {self.temp_folder}")
+
+    def move_files_to_output(self):
+        """Move all files from temp folder to output folder"""
+        if not self.temp_folder:
+            return
+
+        logger.info("Moving files from temp folder to output folder...")
+        for filename in os.listdir(self.temp_folder):
+            src = os.path.join(self.temp_folder, filename)
+            dst = os.path.join(self.config.output_folder, filename)
+            shutil.move(src, dst)
+        logger.info("Successfully moved all files to output folder")
 
     def run(self):
         try:
             book_parser = get_book_parser(self.config)
             tts_provider = get_tts_provider(self.config)
-
-            os.makedirs(self.config.output_folder, exist_ok=True)
+            
             chapters = book_parser.get_chapters(tts_provider.get_break_string())
             # Filter out empty or very short chapters
             chapters = [(title, text) for title, text in chapters if text.strip()]
@@ -75,6 +110,9 @@ class AudiobookGenerator:
             else:
                 confirm_conversion()
 
+            # Setup directories using book title
+            self.setup_directories(book_parser.get_book_title())
+
             # Loop through each chapter and convert it to speech using the provided TTS provider
             for idx, (title, text) in enumerate(chapters, start=1):
                 if idx < self.config.chapter_start:
@@ -86,15 +124,15 @@ class AudiobookGenerator:
                 )
 
                 if self.config.output_text:
-                    text_file = os.path.join(self.config.output_folder, f"{idx:04d}_{title}.txt")
+                    text_file = os.path.join(self.working_dir, f"{idx:04d}_{title}.txt")
                     with open(text_file, "w", encoding='utf-8') as file:
                         file.write(text)
 
                 if self.config.preview:
                     continue
 
-                output_file = os.path.join(self.config.output_folder,
-                                           f"{idx:04d}_{title}.{tts_provider.get_output_file_extension()}")
+                output_file = os.path.join(self.working_dir,
+                                         f"{idx:04d}_{title}.{tts_provider.get_output_file_extension()}")
 
                 audio_tags = AudioTags(title, book_parser.get_book_author(), book_parser.get_book_title(), idx)
                 tts_provider.text_to_speech(
@@ -105,7 +143,13 @@ class AudiobookGenerator:
                 logger.info(
                     f"✅ Converted chapter {idx}/{len(chapters)}: {title}"
                 )
-            logger.info(f"All chapters converted. 🎉🎉🎉")
+
+            logger.info("All chapters converted. 🎉🎉🎉")
+            
+            # Move files from temp to output if using temp dir
+            if self.temp_folder:
+                self.move_files_to_output()
+                self.cleanup_temp_folder()
 
         except KeyboardInterrupt:
             logger.info("Job stopped by user.")

--- a/main.py
+++ b/main.py
@@ -11,6 +11,11 @@ from audiobook_generator.tts_providers.base_tts_provider import (
 def handle_args():
     parser = argparse.ArgumentParser(description="Convert text book to audiobook")
     parser.add_argument("input_file", help="Path to the EPUB file")
+    parser.add_argument(
+        "--temp_dir",
+        default="tmp",
+        help="Path to temporary directory (default: 'tmp' in working directory). Files will be written here first, then moved to output folder.",
+    )
     parser.add_argument("output_folder", help="Path to the output folder")
     parser.add_argument(
         "--tts",

--- a/main.py
+++ b/main.py
@@ -12,9 +12,9 @@ def handle_args():
     parser = argparse.ArgumentParser(description="Convert text book to audiobook")
     parser.add_argument("input_file", help="Path to the EPUB file")
     parser.add_argument(
-        "--temp_dir",
-        default="tmp",
-        help="Path to temporary directory (default: 'tmp' in working directory). Files will be written here first, then moved to output folder.",
+        "--use_temp_dir",
+        action="store_true",
+        help="Use temporary directory ('tmp' in working directory) for processing files before moving them to output folder.",
     )
     parser.add_argument("output_folder", help="Path to the output folder")
     parser.add_argument(


### PR DESCRIPTION
Hey y'all! I have a use-case where I want to automate some steps that happen after epub -> audio conversion is completed for the entire book. I can imagine other users would have similar use cases (e.g. move completed audiobook to remote location, [manually trigger a scan on Audiobookshelf](https://api.audiobookshelf.org/#scan-a-library-39-s-folders) to import the audiobook immediately, or generally run any post-processing on the completed audiobook).

**Why this method?**
Mainly because it seemed like the easiest and most versatile. Using a temporary directory when converting the files, and then moving them all at once to a final output directory allows users to choose how to trigger/act on the final output. Now users can watch the output directory and wait for **any** files to be there (instead of before, when they would have to figure out a way to know how many files would be produced and then wait for **all files in the book** to be there before beginning post-processing).

**High-Level Changes**
- Added temporary directory support with `--use_temp_dir` flag
- When flag is included in command:
  - Output files (including output_text .txt files, if specified) are written a sub-folder in the `tmp` directory.
  - The sub-folder is named based on the book's name.
  -  When the conversion completes, all output files are copied to the output folder. The sub-folder in the `tmp` directory and all its files are removed.
- When flag is **not** included in command:
  - No changes from default behavior (all files written directly to output)
- The location of `tmp` is in the working directory. This is not configurable. (I originally made it configurable, but then decided this wasn't useful and removed it)

(I did not include any updates noting this change in the README. Happy to do so, or let the maintainers update as they desire.)