### PR TITLE
Add OpenAICompatibleTTSProvider for use with compatible third-party service

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,14 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  --tts {azure,openai,edge,piper}
+  --tts {azure,openai,openai_compatible,edge,piper}
                         Choose TTS provider (default: azure). azure: Azure
                         Cognitive Services, openai: OpenAI TTS API. When using
                         azure, environment variables MS_TTS_KEY and
                         MS_TTS_REGION must be set. When using openai,
                         environment variable OPENAI_API_KEY must be set.
+                        When using openai_compatible, both environment variables 
+                        OPENAI_BASE_URL and OPENAI_API_KEY must be set
   --log {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         Log level (default: INFO), can be DEBUG, INFO,
                         WARNING, ERROR, CRITICAL
@@ -305,6 +307,16 @@ Check this [step by step guide](https://gist.github.com/p0n1/cba98859cdb6331cc1a
 ## How to Get Your OpenAI API Key?
 
 Check https://platform.openai.com/docs/quickstart/account-setup. Make sure you check the [price](https://openai.com/pricing) details before use.
+
+## Using an OpenAI-compatible service
+
+It is possible to use an OpenAI-compatible service, like [matatonic/openedai-speech](https://github.com/matatonic/openedai-speech). In that case, it **is required** to set the `OPENAI_BASE_URL` environment variable, otherwise it would just default to the standard OpenAI service. While the compatible service might not require an API key, the OpenAI client still does, so make sure to set it to something nonsensical.
+
+If your OpenAI-compatible service is running on `http://127.0.0.1:8000` and you have added a custom voice named `skippy`, you can use the following command:
+
+```shell
+docker run -i -t --rm -v ./:/app -e OPENAI_BASE_URL=http://127.0.0.1:8000/v1 -e OPENAI_API_KEY=nope ghcr.io/p0n1/epub_to_audiobook your_book.epub audiobook_output --tts openai_compatible --voice_name=skippy --model_name=tts-1-hd
+```
 
 ## ✨ About Edge TTS
 

--- a/audiobook_generator/core/audiobook_generator.py
+++ b/audiobook_generator/core/audiobook_generator.py
@@ -65,7 +65,11 @@ class AudiobookGenerator:
             total_characters = get_total_chars(chapters[self.config.chapter_start - 1:self.config.chapter_end])
             logger.info(f"✨ Total characters in selected book chapters: {total_characters} ✨")
             rough_price = tts_provider.estimate_cost(total_characters)
-            print(f"Estimate book voiceover would cost you roughly: ${rough_price:.2f}\n")
+            if rough_price:
+                print(f"Estimate book voiceover would cost you roughly: ${rough_price:.2f}\n")
+            else:
+                print("Unable to estimate book voiceover cost.")
+
 
             # Prompt user to continue if not in preview mode
             if self.config.no_prompt:

--- a/audiobook_generator/tts_providers/base_tts_provider.py
+++ b/audiobook_generator/tts_providers/base_tts_provider.py
@@ -4,6 +4,7 @@ from audiobook_generator.config.general_config import GeneralConfig
 
 TTS_AZURE = "azure"
 TTS_OPENAI = "openai"
+TTS_OPENAI_COMPATIBLE = "openai_compatible"
 TTS_EDGE = "edge"
 TTS_PIPER = "piper"
 TTS_PIPER_DOCKER = "piper_docker"
@@ -36,7 +37,7 @@ class BaseTTSProvider:  # Base interface for TTS providers
 
 # Common support methods for all TTS providers
 def get_supported_tts_providers() -> List[str]:
-    return [TTS_AZURE, TTS_OPENAI, TTS_EDGE, TTS_PIPER, TTS_PIPER_DOCKER]
+    return [TTS_AZURE, TTS_OPENAI, TTS_OPENAI_COMPATIBLE, TTS_EDGE, TTS_PIPER, TTS_PIPER_DOCKER]
 
 
 def get_tts_provider(config) -> BaseTTSProvider:
@@ -52,6 +53,12 @@ def get_tts_provider(config) -> BaseTTSProvider:
         )
 
         return OpenAITTSProvider(config)
+    elif config.tts == TTS_OPENAI_COMPATIBLE:
+        from audiobook_generator.tts_providers.openai_compatible_tts_provider import (
+            OpenAICompatibleTTSProvider,
+        )
+
+        return OpenAICompatibleTTSProvider(config)
     elif config.tts == TTS_EDGE:
         from audiobook_generator.tts_providers.edge_tts_provider import EdgeTTSProvider
 

--- a/audiobook_generator/tts_providers/openai_compatible_tts_provider.py
+++ b/audiobook_generator/tts_providers/openai_compatible_tts_provider.py
@@ -1,0 +1,12 @@
+import os
+
+from audiobook_generator.tts_providers.openai_tts_provider import OpenAITTSProvider
+
+
+class OpenAICompatibleTTSProvider(OpenAITTSProvider):
+    def validate_config(self):
+        if not os.environ.get('OPENAI_BASE_URL'):
+            raise ValueError(f"OpenAICompatible: Environment variable 'OPENAI_BASE_URL' is not set.")
+
+    def estimate_cost(self, total_chars):
+        return None

--- a/tests/args_test.py
+++ b/tests/args_test.py
@@ -17,6 +17,12 @@ class TestHandleArgs(unittest.TestCase):
         config = handle_args()
         self.assertEqual(config.tts, 'openai')
 
+    # Test openai_compatible arguments
+    @patch('sys.argv', ['program', 'input_file.epub', 'output_folder', '--tts', 'openai_compatible'])
+    def test_openai_compatible_args(self):
+        config = handle_args()
+        self.assertEqual(config.tts, 'openai_compatible')
+
     # Test unsupported TTS provider
     @patch('sys.argv', ['program', 'input_file.epub', 'output_folder', '--tts', 'unsupported_tts'])
     def test_unsupported_tts(self):


### PR DESCRIPTION
I have created a 'pass-through' TTS Provider for use with OpenAI-compatible services (in my case, https://github.com/matatonic/openedai-speech). The upside is that this can run locally and allows for custom voices.

All I did was extend the OpenAI TTS, and override the validation and cost functions. Since it relies on core OpenAI functionality, all the end user has to do is set the `OPENAI_BASE_URL` with their own custom path, and it will work.

Since this is such a very simple TTS provider (all the heavy lifting is done by the existing provider), I have not added any tests beyond the argument test, but I have updated the README. I hope this is okay.