### PR TITLE
Ease OpenAI TTS Provider validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,16 @@ Here are some examples that demonstrate various option combinations:
    python3 main.py "path/to/book.epub" "path/to/output/folder" --tts openai --preview --output_text
    ```
 
+## Example using an OpenAI-compatible service
+
+It is possible to use an OpenAI-compatible service, like [matatonic/openedai-speech](https://github.com/matatonic/openedai-speech). In that case, it **is required** to set the `OPENAI_BASE_URL` environment variable, otherwise it would just default to the standard OpenAI service. While the compatible service might not require an API key, the OpenAI client still does, so make sure to set it to something nonsensical.
+
+If your OpenAI-compatible service is running on `http://127.0.0.1:8000` and you have added a custom voice named `skippy`, you can use the following command:
+
+```shell
+docker run -i -t --rm -v ./:/app -e OPENAI_BASE_URL=http://127.0.0.1:8000/v1 -e OPENAI_API_KEY=nope ghcr.io/p0n1/epub_to_audiobook your_book.epub audiobook_output --tts openai --voice_name=skippy --model_name=tts-1-hd
+```
+
 ### Examples Using Edge TTS
 
 1. **Basic conversion using Edge with default settings**  

--- a/audiobook_generator/tts_providers/openai_tts_provider.py
+++ b/audiobook_generator/tts_providers/openai_tts_provider.py
@@ -13,16 +13,8 @@ from audiobook_generator.tts_providers.base_tts_provider import BaseTTSProvider
 logger = logging.getLogger(__name__)
 
 
-def get_supported_models():
-    return ["tts-1", "tts-1-hd"]
-
-
-def get_supported_voices():
-    return ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
-
-
 def get_supported_formats():
-    return ["mp3", "aac", "flac", "opus"]
+    return ["mp3", "aac", "flac", "opus", "wav"]
 
 
 class OpenAITTSProvider(BaseTTSProvider):
@@ -80,10 +72,6 @@ class OpenAITTSProvider(BaseTTSProvider):
         return self.config.output_format
 
     def validate_config(self):
-        if self.config.model_name not in get_supported_models():
-            raise ValueError(f"OpenAI: Unsupported model name: {self.config.model_name}")
-        if self.config.voice_name not in get_supported_voices():
-            raise ValueError(f"OpenAI: Unsupported voice name: {self.config.voice_name}")
         if self.config.output_format not in get_supported_formats():
             raise ValueError(f"OpenAI: Unsupported output format: {self.config.output_format}")
 


### PR DESCRIPTION
To support new voices and allow for use with compatible services.

Since [Kokoro-FastAPI also requires a custom model](https://github.com/remsky/Kokoro-FastAPI/blob/master/api/src/structures/schemas.py#L26), I have also removed the validation for the model parameter.