### PR TITLE
Remove reference numbers option

### DIFF
--- a/audiobook_generator/book_parsers/epub_book_parser.py
+++ b/audiobook_generator/book_parsers/epub_book_parser.py
@@ -67,6 +67,11 @@ class EpubBookParser(BaseBookParser):
                 cleaned_text = re.sub(r'(?<=[a-zA-Z.,!?;”")])\d+', "", cleaned_text)
                 logger.debug(f"Cleaned text step 4: <{cleaned_text[:100]}>")
 
+            # Removes references numbers like [1] or [2.3]
+            if self.config.remove_reference_numbers
+                cleaned_text = re.sub(r'\[\d+(\.\d+)?\]', '', cleaned_text)
+                logger.debug(f"Cleaned text step 4.1 (removed brackets): <{cleaned_text[:100]}>")
+
             # Does user defined search and replaces
             for search_and_replace in search_and_replaces:
                 cleaned_text = re.sub(search_and_replace['search'], search_and_replace['replace'], cleaned_text)

--- a/audiobook_generator/book_parsers/epub_book_parser.py
+++ b/audiobook_generator/book_parsers/epub_book_parser.py
@@ -68,7 +68,7 @@ class EpubBookParser(BaseBookParser):
                 logger.debug(f"Cleaned text step 4: <{cleaned_text[:100]}>")
 
             # Removes references numbers like [1] or [2.3]
-            if self.config.remove_reference_numbers
+            if self.config.remove_reference_numbers:
                 cleaned_text = re.sub(r'\[\d+(\.\d+)?\]', '', cleaned_text)
                 logger.debug(f"Cleaned text step 4.1 (removed brackets): <{cleaned_text[:100]}>")
 

--- a/audiobook_generator/config/general_config.py
+++ b/audiobook_generator/config/general_config.py
@@ -14,6 +14,7 @@ class GeneralConfig:
         self.chapter_start = args.chapter_start
         self.chapter_end = args.chapter_end
         self.remove_endnotes = args.remove_endnotes
+        self.remove_reference_numbers = args.remove_reference_numbers
         self.search_and_replace_file = args.search_and_replace_file
 
         # TTS provider: common arguments

--- a/main.py
+++ b/main.py
@@ -75,6 +75,12 @@ def handle_args():
     )
 
     parser.add_argument(
+        "--remove_reference_numbers",
+        action="store_true",
+        help="This will remove reference numbers from the end or middle of sentences (e.g [3] or [12.1]). Also useful for academic books."
+    )
+
+    parser.add_argument(
         "--search_and_replace_file",
         default="",
         help="""Path to a file that contains 1 regex replace per line, to help with fixing pronunciations, etc. The format is:


### PR DESCRIPTION
Adding in a CLI option to remove reference numbers from text (e.g. [12] [3.5])