### PR TITLE
Add new features for openai tts as requested in #120

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ options:
   --model_name MODEL_NAME
                         Various TTS providers has different neural model names
 
+openai specific:
+  --speed SPEED         The speed of the generated audio. Select a value from 0.25 to 4.0. 1.0 is the default.
+  --instructions INSTRUCTIONS
+                        Instructions for the TTS model. Only supported for 'gpt-4o-mini-tts' model.
+
 edge specific:
   --voice_rate VOICE_RATE
                         Speaking rate of the text. Valid relative values range

--- a/audiobook_generator/config/general_config.py
+++ b/audiobook_generator/config/general_config.py
@@ -23,6 +23,10 @@ class GeneralConfig:
         self.output_format = args.output_format
         self.model_name = args.model_name
 
+        # OpenAI specific arguments
+        self.instructions = args.instructions
+        self.speed = args.speed
+
         # TTS provider: Azure & Edge TTS specific arguments
         self.break_duration = args.break_duration
 

--- a/audiobook_generator/tts_providers/openai_tts_provider.py
+++ b/audiobook_generator/tts_providers/openai_tts_provider.py
@@ -94,10 +94,6 @@ class OpenAITTSProvider(BaseTTSProvider):
     def validate_config(self):
         if self.config.output_format not in get_supported_formats():
             raise ValueError(f"OpenAI: Unsupported output format: {self.config.output_format}")
-        if self.config.voice_name not in get_supported_voices():
-            raise ValueError(f"OpenAI: Unsupported voice name: {self.config.voice_name}")
-        if self.config.model_name not in get_supported_models():
-            raise ValueError(f"OpenAI: Unsupported model name: {self.config.model_name}")
         if self.config.speed < 0.25 or self.config.speed > 4.0:
             raise ValueError(f"OpenAI: Unsupported speed: {self.config.speed}")
         if self.config.instructions and len(self.config.instructions) > 0 and self.config.model_name != "gpt-4o-mini-tts":

--- a/audiobook_generator/tts_providers/openai_tts_provider.py
+++ b/audiobook_generator/tts_providers/openai_tts_provider.py
@@ -31,7 +31,8 @@ def get_price(model):
     elif model == "gpt-4o-mini-tts": # $12 per 1 mil tokens (not chars, as 1 token is ~4 chars)
         return 0.003
     else:
-        raise ValueError(f"OpenAI: Unsupported model name: {model}")
+        logger.warning(f"OpenAI: Unsupported model name: {model}, unable to retrieve the price")
+        return 0.0
 
 
 class OpenAITTSProvider(BaseTTSProvider):

--- a/audiobook_generator/tts_providers/openai_tts_provider.py
+++ b/audiobook_generator/tts_providers/openai_tts_provider.py
@@ -16,15 +16,33 @@ logger = logging.getLogger(__name__)
 def get_supported_formats():
     return ["mp3", "aac", "flac", "opus", "wav"]
 
+def get_supported_voices():
+    return ["alloy", "ash", "ballad", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer", "verse"]
+
+def get_supported_models():
+    return ["tts-1", "tts-1-hd", "gpt-4o-mini-tts"]
+
+def get_price(model):
+    # https://platform.openai.com/docs/pricing#transcription-and-speech-generation
+    if model == "tts-1": # $15 per 1 mil chars
+        return 0.015
+    elif model == "tts-1-hd": # $30 per 1 mil chars
+        return 0.03
+    elif model == "gpt-4o-mini-tts": # $12 per 1 mil tokens (not chars, as 1 token is ~4 chars)
+        return 0.003
+    else:
+        raise ValueError(f"OpenAI: Unsupported model name: {model}")
+
 
 class OpenAITTSProvider(BaseTTSProvider):
     def __init__(self, config: GeneralConfig):
-        config.model_name = config.model_name or "tts-1"
+        config.model_name = config.model_name or "gpt-4o-mini-tts" # default to this model as it's the cheapest
         config.voice_name = config.voice_name or "alloy"
+        config.speed = config.speed or 1.0
+        config.instructions = config.instructions or None
         config.output_format = config.output_format or "mp3"
 
-        # per 1000 characters (0.03$ for HD model, 0.015$ for standard model)
-        self.price = 0.03 if config.model_name == "tts-1-hd" else 0.015
+        self.price = get_price(config.model_name)
         super().__init__(config)
 
         self.client = OpenAI()  # User should set OPENAI_API_KEY environment variable
@@ -53,6 +71,8 @@ class OpenAITTSProvider(BaseTTSProvider):
             response = self.client.audio.speech.create(
                 model=self.config.model_name,
                 voice=self.config.voice_name,
+                speed=self.config.speed,
+                instructions=self.config.instructions,
                 input=chunk,
                 response_format=self.config.output_format,
             )
@@ -74,6 +94,14 @@ class OpenAITTSProvider(BaseTTSProvider):
     def validate_config(self):
         if self.config.output_format not in get_supported_formats():
             raise ValueError(f"OpenAI: Unsupported output format: {self.config.output_format}")
+        if self.config.voice_name not in get_supported_voices():
+            raise ValueError(f"OpenAI: Unsupported voice name: {self.config.voice_name}")
+        if self.config.model_name not in get_supported_models():
+            raise ValueError(f"OpenAI: Unsupported model name: {self.config.model_name}")
+        if self.config.speed < 0.25 or self.config.speed > 4.0:
+            raise ValueError(f"OpenAI: Unsupported speed: {self.config.speed}")
+        if self.config.instructions and len(self.config.instructions) > 0 and self.config.model_name != "gpt-4o-mini-tts":
+            raise ValueError(f"OpenAI: Instructions are only supported for 'gpt-4o-mini-tts' model")
 
     def estimate_cost(self, total_chars):
         return math.ceil(total_chars / 1000) * self.price

--- a/main.py
+++ b/main.py
@@ -98,6 +98,19 @@ def handle_args():
         help="Various TTS providers has different neural model names",
     )
 
+    openai_tts_group = parser.add_argument_group(title="openai specific")
+    openai_tts_group.add_argument(
+        "--speed",
+        default=1.0,
+        type=float,
+        help="The speed of the generated audio. Select a value from 0.25 to 4.0. 1.0 is the default.",
+    )
+
+    openai_tts_group.add_argument(
+        "--instructions",
+        help="Instructions for the TTS model. Only supported for 'gpt-4o-mini-tts' model.",
+    )
+
     edge_tts_group = parser.add_argument_group(title="edge specific")
     edge_tts_group.add_argument(
         "--voice_rate",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 beautifulsoup4==4.12.3
 EbookLib==0.18
 mutagen==1.47.0
-openai==1.35.7
+openai==1.68.2
 requests==2.32.3
-socksio==1.0.0
 edge-tts==6.1.12
 pydub==0.25.1
 wyoming==1.6.0

--- a/tests/audiobook_generator/tts_providers/openai_tts_provider_test.py
+++ b/tests/audiobook_generator/tts_providers/openai_tts_provider_test.py
@@ -30,7 +30,7 @@ class TestOpenAiTtsProvider(unittest.TestCase):
         config.output_format = None
         tts_provider = get_tts_provider(config)
         self.assertIsInstance(tts_provider, OpenAITTSProvider)
-        self.assertEqual(tts_provider.config.model_name, "tts-1")
+        self.assertEqual(tts_provider.config.model_name, "gpt-4o-mini-tts")
         self.assertEqual(tts_provider.config.voice_name, "alloy")
         self.assertEqual(tts_provider.config.output_format, "mp3")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,6 +38,7 @@ def get_openai_config():
         language='en-US',
         voice_name='echo',
         output_format='mp3',
-        model_name='tts-1'
+        model_name='tts-1',
+        speed=1.0
     )
     return GeneralConfig(args)


### PR DESCRIPTION
Here is a list of fixes:

* Pump OpenAI lib from `1.35.7` to `1.68.2`
* Remove unused `socksio` as per #114 
* Update README.md with new args specifically for OpenAI
* Update general config to include 2 new params
* Update OpenAI TTS Provide:
    * Improve config validation check for:
        * Models
        * Voices
        * Speed
        * Instructions
    * Improve price calculation
    * Include new params (`speed` and `instructions`) as per request in #120
    * Set the default model to `gpt-4o-mini-tts` as it is the cheapest now
* Fix tests as the default model was changed