### PR TITLE
Kokoro updates for docs and docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ Then in another tab, run
 ```bash
 export OPENAI_BASE_URL=http://localhost:8880/v1
 export OPENAI_API_KEY="fake"
-python main.py path/to/epub output-dir --tts openai --voice_name "af_bella(3)+af_alloy(1)" #you can replace this with any other voice name. Link below.
+python main.py path/to/epub output-dir --tts openai --voice_name "af_bella(3)+af_alloy(1) --model_name tts-1" #you can replace this with any other voice name. Link below. Also note that model_name tts-1 is required since kokoro breaks with the current default model_name value.
 ```
 
 Alternatively, you can do the entire set up through docker compose using the [docker compose file set up for kokoro](./docker-compose.kokoro-example.yml).

--- a/README.md
+++ b/README.md
@@ -497,8 +497,9 @@ Then in another tab, run
 ```bash
 export OPENAI_BASE_URL=http://localhost:8880/v1
 export OPENAI_API_KEY="fake"
-python main.py path/to/epub output-dir --tts openai --voice_name "af_bella(3)+af_alloy(1) --model_name tts-1" #you can replace this with any other voice name. Link below. Also note that model_name tts-1 is required since kokoro breaks with the current default model_name value.
+python main.py path/to/epub output-dir --tts openai --voice_name "af_bella(3)+af_alloy(1) --model_name tts-1" #you can replace this with any other voice name. Link below. 
 ```
+Note that passing `--model_name tts-1` parameter **is required** since kokoro breaks with the current default model_name value.
 
 Alternatively, you can do the entire set up through docker compose using the [docker compose file set up for kokoro](./docker-compose.kokoro-example.yml).
 

--- a/docker-compose.kokoro-example.yml
+++ b/docker-compose.kokoro-example.yml
@@ -44,6 +44,7 @@ services:
       "${OUTPUT_DIR}"
       --tts openai
       --no_prompt
+      --model_name tts-1
       --voice_name '${VOICE_NAME}'
     depends_on:
       kokoro:


### PR DESCRIPTION
Added some clarification to kokoro documentation and to the docker compose file. 

We have to pass ``--model_name tts-1`` if running against a kokoro endpoint since the current code passes a default model_name that breaks kokoro.