### PR TITLE
Add a option to use pydub package for merging audio segments

### DIFF
--- a/audiobook_generator/config/general_config.py
+++ b/audiobook_generator/config/general_config.py
@@ -9,6 +9,7 @@ class GeneralConfig:
         self.no_prompt = args.no_prompt
         self.title_mode = args.title_mode
         self.worker_count = args.worker_count
+        self.use_pydub_merge = args.use_pydub_merge
 
         # Book parser specific arguments
         self.newline_mode = args.newline_mode

--- a/audiobook_generator/core/audiobook_generator.py
+++ b/audiobook_generator/core/audiobook_generator.py
@@ -80,7 +80,7 @@ class AudiobookGenerator:
             )
             tts_provider.text_to_speech(text, output_file, audio_tags)
 
-            logger.info(f"✅ Converted chapter {idx}: {title}")
+            logger.info(f"✅ Converted chapter {idx}: {title}, output file: {output_file}")
 
             return True
         except Exception as e:

--- a/audiobook_generator/core/utils.py
+++ b/audiobook_generator/core/utils.py
@@ -1,5 +1,9 @@
 import logging
-from typing import List
+from typing import List, Tuple
+import tempfile
+import os
+import io
+from pydub import AudioSegment
 from mutagen.id3._frames import TIT2, TPE1, TALB, TRCK
 from mutagen.id3 import ID3, ID3NoHeaderError
 
@@ -73,3 +77,103 @@ def is_special_char(char: str) -> bool:
     )  # special unicode punctuation
     logger.debug(f"is_special_char> char={char}, ord={ord_char}, result={result}")
     return result
+
+
+def save_segment_tmp(segment: io.BytesIO, output_format: str, prefix: str = None) -> str:
+    """
+    Save audio segment to a temporary file
+    
+    Args:
+        segment: Audio segment (io.BytesIO)
+        output_format: Audio file format
+        prefix: Optional prefix for the temporary filename
+        
+    Returns:
+        Path to the temporary file
+    """
+    kwargs = {"delete": False, "suffix": f".{output_format}"}
+    if prefix:
+        kwargs["prefix"] = f"{prefix}_"
+        
+    with tempfile.NamedTemporaryFile(**kwargs) as tmp_file:
+        segment.seek(0)
+        tmp_file.write(segment.read())
+        logger.debug(f"Audio segment written to temporary file: {tmp_file.name}")
+        return tmp_file.name
+
+
+def pydub_merge_audio_segments(tmp_files: List[str], output_file: str, output_format: str) -> None:
+    """
+    Merge multiple audio segments into one and set audio tags
+    
+    Args:
+        tmp_files: List of temporary file paths
+        output_file: Path to the final output file
+        output_format: Audio file format
+    """
+    if not tmp_files:
+        logger.warning("No temporary files to merge")
+        return
+        
+    combined = AudioSegment.empty()
+    for tmp_file in tmp_files:
+        logger.debug(f"Loading chunk from temporary file: {tmp_file}")
+        segment = AudioSegment.from_file(tmp_file)
+        combined += segment
+        
+    # Export to final output file
+    logger.debug(f"Exporting to final output file: {output_file}")
+    combined.export(output_file, format=output_format)
+    logger.debug(f"Final output file exported: {output_file}")
+
+    # Delete the temporary files
+    for tmp_file in tmp_files:
+        os.remove(tmp_file)
+    logger.debug(f"Temporary files deleted: {tmp_files}")
+
+
+def direct_merge_audio_segments(audio_segments: List[io.BytesIO], output_file: str) -> None:
+    """
+    Directly write multiple audio segments into one file without using pydub
+    
+    Args:
+        audio_segments: List of audio segments in memory
+        output_file: Path to the final output file
+    """
+    if not audio_segments:
+        logger.warning("No audio segments to write")
+        return
+        
+    logger.debug(f"Writing audio segments directly to file: {output_file}")
+    with open(output_file, "wb") as outfile:
+        for segment in audio_segments:
+            segment.seek(0)
+            outfile.write(segment.read())
+    logger.debug(f"Direct writing completed: {output_file}")
+
+
+def merge_audio_segments(audio_segments: List[io.BytesIO], output_file: str, output_format: str, 
+                          chunk_ids: List[str], use_pydub_merge: bool) -> None:
+    """
+    Merge audio segments using either pydub or direct write method based on configuration
+    
+    Args:
+        audio_segments: List of audio segments (BytesIO objects)
+        output_file: Path to the final output file
+        output_format: Audio file format
+        chunk_ids: List of IDs for each audio chunk
+        use_pydub_merge: Whether to use pydub for merging (True) or direct write (False)
+    """
+    if use_pydub_merge:
+        logger.info(f"Using pydub to merge audio segments: {chunk_ids}")
+        tmp_files = []
+        for i, segment in enumerate(audio_segments):
+            tmp_file_path = save_segment_tmp(segment, output_format, chunk_ids[i])
+            tmp_files.append(tmp_file_path)
+
+        # Merge all audio chunks with pydub and create the final output file
+        pydub_merge_audio_segments(tmp_files, output_file, output_format)
+    else:
+        logger.info(f"Using direct write to merge audio segments: {chunk_ids}")
+        # Direct write audio segments to output file
+        direct_merge_audio_segments(audio_segments, output_file)

--- a/audiobook_generator/tts_providers/azure_tts_provider.py
+++ b/audiobook_generator/tts_providers/azure_tts_provider.py
@@ -20,7 +20,10 @@ MAX_RETRIES = 12  # Max_retries constant for network errors
 class AzureTTSProvider(BaseTTSProvider):
     def __init__(self, config: GeneralConfig):
         # TTS provider specific config
-        config.voice_name = config.voice_name or "en-US-GuyNeural"
+        if config.language == "zh-CN":
+            config.voice_name = config.voice_name or "zh-CN-YunyeNeural"
+        else:
+            config.voice_name = config.voice_name or "en-US-GuyNeural"
         config.output_format = config.output_format or "audio-24khz-48kbitrate-mono-mp3"
 
         # 16$ per 1 million characters

--- a/audiobook_generator/tts_providers/edge_tts_provider.py
+++ b/audiobook_generator/tts_providers/edge_tts_provider.py
@@ -125,7 +125,10 @@ class CommWithPauses:
 class EdgeTTSProvider(BaseTTSProvider):
     def __init__(self, config: GeneralConfig):
         # TTS provider specific config
-        config.voice_name = config.voice_name or "en-US-GuyNeural"
+        if config.language == "zh-CN":
+            config.voice_name = config.voice_name or "zh-CN-YunxiNeural"
+        else:
+            config.voice_name = config.voice_name or "en-US-GuyNeural"
         config.output_format = config.output_format or "audio-24khz-48kbitrate-mono-mp3"
         config.voice_rate = config.voice_rate or "+0%"
         config.voice_volume = config.voice_volume or "+0%"

--- a/audiobook_generator/tts_providers/openai_tts_provider.py
+++ b/audiobook_generator/tts_providers/openai_tts_provider.py
@@ -1,12 +1,15 @@
 import io
 import logging
 import math
+import tempfile
+import os
+from pydub import AudioSegment
 
 from openai import OpenAI
 
 from audiobook_generator.core.audio_tags import AudioTags
 from audiobook_generator.config.general_config import GeneralConfig
-from audiobook_generator.core.utils import split_text, set_audio_tags
+from audiobook_generator.core.utils import split_text, set_audio_tags, merge_audio_segments
 from audiobook_generator.tts_providers.base_tts_provider import BaseTTSProvider
 
 
@@ -60,16 +63,16 @@ class OpenAITTSProvider(BaseTTSProvider):
         text_chunks = split_text(text, max_chars, self.config.language)
 
         audio_segments = []
+        chunk_ids = []
 
         for i, chunk in enumerate(text_chunks, 1):
-            logger.debug(
-                f"Processing chunk {i} of {len(text_chunks)}, length={len(chunk)}, text=[{chunk}]"
-            )
+            chunk_id = f"chapter-{audio_tags.idx}_{audio_tags.title}_chunk_{i}_of_{len(text_chunks)}"
             logger.info(
-                f"Processing chapter-{audio_tags.idx} <{audio_tags.title}>, chunk {i} of {len(text_chunks)}"
+                f"Processing {chunk_id}, length={len(chunk)}"
             )
-
-            logger.debug(f"Text: [{chunk}], length={len(chunk)}")
+            logger.debug(
+                f"Processing {chunk_id}, length={len(chunk)}, text=[{chunk}]"
+            )
 
             # NO retry for OpenAI TTS because SDK has built-in retry logic
             response = self.client.audio.speech.create(
@@ -80,12 +83,17 @@ class OpenAITTSProvider(BaseTTSProvider):
                 input=chunk,
                 response_format=self.config.output_format,
             )
-            audio_segments.append(io.BytesIO(response.content))
 
-        with open(output_file, "wb") as outfile:
-            for segment in audio_segments:
-                segment.seek(0)
-                outfile.write(segment.read())
+            # Log response details
+            logger.debug(f"Remote server response: status_code={response.response.status_code}, "
+                         f"size={len(response.content)} bytes, "
+                         f"content={response.content[:128]}...")
+            
+            audio_segments.append(io.BytesIO(response.content))
+            chunk_ids.append(chunk_id)
+        
+        # Use utility function to merge audio segments
+        merge_audio_segments(audio_segments, output_file, self.config.output_format, chunk_ids, self.config.use_pydub_merge)
 
         set_audio_tags(output_file, audio_tags)
 

--- a/audiobook_generator/tts_providers/openai_tts_provider.py
+++ b/audiobook_generator/tts_providers/openai_tts_provider.py
@@ -49,7 +49,7 @@ class OpenAITTSProvider(BaseTTSProvider):
         self.price = get_price(config.model_name)
         super().__init__(config)
 
-        self.client = OpenAI()  # User should set OPENAI_API_KEY environment variable
+        self.client = OpenAI(max_retries=4)  # User should set OPENAI_API_KEY environment variable
 
     def __str__(self) -> str:
         return super().__str__()

--- a/main.py
+++ b/main.py
@@ -99,6 +99,18 @@ def handle_args():
     )
 
     parser.add_argument(
+        "--use_pydub_merge",
+        action="store_true",
+        help="Use pydub to merge audio segments of one chapter into single file instead of direct write. "
+        "Currently only supported for OpenAI and Azure TTS. "
+        "Direct write is faster but might skip audio segments if formats differ. "
+        "Pydub merge is slower but more reliable for different audio formats. It requires ffmpeg to be installed first. "
+        "You can use this option to avoid the issue of skipping audio segments in some cases. "
+        "However, it's recommended to use direct write for most cases as it's faster. "
+        "Only use this option if you encounter issues with direct write.",
+    )
+
+    parser.add_argument(
         "--voice_name",
         help="Various TTS providers has different voice names, look up for your provider settings.",
     )


### PR DESCRIPTION
Users could try `--use_pydub_merge` to use pydub to merge audio segments of one chapter into single file instead of direct write.

Currently only supported for OpenAI and Azure TTS.

Direct write is faster but might skip audio segments if formats differ.
Pydub merge is slower but more reliable for different audio formats. It requires `ffmpeg` to be installed first.

You can use this option to avoid the issue of skipping audio segments in some cases. However, it's recommended to use direct write for most cases as it's faster. Only use this option if you encounter issues with direct write.

The direct write merge actually would skip some audio files silently, which would cause the final audio file incomplete.

https://github.com/p0n1/epub_to_audiobook/blob/fa45ee02e9776f57d73f0cd8252e1f57c0ffb145/audiobook_generator/tts_providers/openai_tts_provider.py#L85-L88

I found such case when playing with https://github.com/dbccccccc/ttsfm. The OpenAI.fm service has some unknown inconsistencies, and the audio files it returns can be in different formats. This causes the code in our project that was originally meant to directly merge audio files to not work properly, resulting in incomplete merged audio files.
