### PR TITLE
Kokoro docker compose - enable gpu resources

### DIFF
--- a/docker-compose.kokoro-example.yml
+++ b/docker-compose.kokoro-example.yml
@@ -22,6 +22,13 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+#    deploy: #uncomment this section if you are using the GPU image
+#      resources:
+#        reservations:
+#          devices:
+#            - driver: nvidia
+#              count: all
+#              capabilities: [gpu]
 
   epub_to_audiobook:
     build:


### PR DESCRIPTION
I had this issue on my machine (Windows), where the Kokoro container would fail to register gpus.
Adding the following section fixed the issue