### PR TITLE
fix: update base image in Dockerfile to Python 3.11-slim-trixie to use ffmpeg 7.1.1-1 instead of 5.1.6-0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.11-slim-bookworm
+FROM python:3.11-slim-trixie
 
 # Set environment variables to prevent Python from buffering stdout/stderr
 # This is to ensure print statements appear in Docker logs


### PR DESCRIPTION
I found the root cause of issue https://github.com/p0n1/epub_to_audiobook/issues/156 could be the outdated ffmpeg.

The python:3.11-slim-bookworm is using ffmpeg 5.1.6-0 and python:3.11-slim-trixie is using 7.1.1-1.

https://packages.debian.org/search?searchon=sourcenames&keywords=ffmpeg

I tried the updated container and found the squeaking audio issue is relieved.

This could also be related with a lower default bitrate is used during generated audio merging, which I would try to resolve in another PR.