### PR TITLE
feat: add CAMB AI as a TTS provider

### DIFF
--- a/audiobook_generator/config/general_config.py
+++ b/audiobook_generator/config/general_config.py
@@ -49,5 +49,9 @@ class GeneralConfig:
         self.piper_length_scale = getattr(args, 'piper_length_scale', None)
         self.piper_sentence_silence = getattr(args, 'piper_sentence_silence', None)
 
+        # TTS provider: CAMB AI specific arguments
+        self.speaking_rate = getattr(args, 'speaking_rate', None)
+        self.camb_instructions = getattr(args, 'camb_instructions', None)
+
     def __str__(self):
         return ",\n".join(f"{key}={value}" for key, value in self.__dict__.items())

--- a/audiobook_generator/tts_providers/base_tts_provider.py
+++ b/audiobook_generator/tts_providers/base_tts_provider.py
@@ -6,6 +6,7 @@ TTS_AZURE = "azure"
 TTS_OPENAI = "openai"
 TTS_EDGE = "edge"
 TTS_PIPER = "piper"
+TTS_CAMB = "camb"
 
 
 class BaseTTSProvider:  # Base interface for TTS providers
@@ -35,7 +36,7 @@ class BaseTTSProvider:  # Base interface for TTS providers
 
 # Common support methods for all TTS providers
 def get_supported_tts_providers() -> List[str]:
-    return [TTS_AZURE, TTS_OPENAI, TTS_EDGE, TTS_PIPER]
+    return [TTS_AZURE, TTS_OPENAI, TTS_EDGE, TTS_PIPER, TTS_CAMB]
 
 
 def get_tts_provider(config) -> BaseTTSProvider:
@@ -59,5 +60,9 @@ def get_tts_provider(config) -> BaseTTSProvider:
         from audiobook_generator.tts_providers.piper_tts_provider import PiperTTSProvider
 
         return PiperTTSProvider(config)
+    elif config.tts == TTS_CAMB:
+        from audiobook_generator.tts_providers.camb_tts_provider import CambTTSProvider
+
+        return CambTTSProvider(config)
     else:
         raise ValueError(f"Invalid TTS provider: {config.tts}")

--- a/audiobook_generator/tts_providers/camb_tts_provider.py
+++ b/audiobook_generator/tts_providers/camb_tts_provider.py
@@ -1,0 +1,178 @@
+import io
+import logging
+import math
+import os
+import time
+
+import requests
+
+from audiobook_generator.core.audio_tags import AudioTags
+from audiobook_generator.config.general_config import GeneralConfig
+from audiobook_generator.utils.utils import split_text, set_audio_tags, merge_audio_segments
+from audiobook_generator.tts_providers.base_tts_provider import BaseTTSProvider
+
+
+logger = logging.getLogger(__name__)
+
+MAX_RETRIES = 4
+RETRY_BACKOFF = 2  # seconds, doubles each retry
+
+
+def get_camb_supported_models():
+    return ["mars-pro", "mars-flash", "mars-instruct"]
+
+
+def get_camb_supported_output_formats():
+    return ["mp3", "wav", "flac"]
+
+
+class CambTTSProvider(BaseTTSProvider):
+    def __init__(self, config: GeneralConfig):
+        config.model_name = config.model_name or "mars-pro"
+        config.output_format = config.output_format or "mp3"
+        config.voice_name = config.voice_name or "147320"
+        config.language = config.language or "en-us"
+
+        super().__init__(config)
+
+        self.api_key = os.environ.get("CAMB_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "CAMB AI: CAMB_API_KEY environment variable must be set"
+            )
+
+    def __str__(self) -> str:
+        return super().__str__()
+
+    def validate_config(self):
+        if self.config.model_name not in get_camb_supported_models():
+            raise ValueError(
+                f"CAMB AI: Unsupported model: {self.config.model_name}. "
+                f"Supported models: {get_camb_supported_models()}"
+            )
+        if self.config.output_format not in get_camb_supported_output_formats():
+            raise ValueError(
+                f"CAMB AI: Unsupported output format: {self.config.output_format}. "
+                f"Supported formats: {get_camb_supported_output_formats()}"
+            )
+        try:
+            int(self.config.voice_name)
+        except (ValueError, TypeError):
+            raise ValueError(
+                f"CAMB AI: voice_name must be a numeric voice ID, got: {self.config.voice_name}"
+            )
+        if (
+            self.config.camb_instructions
+            and self.config.model_name != "mars-instruct"
+        ):
+            raise ValueError(
+                "CAMB AI: Instructions are only supported for 'mars-instruct' model"
+            )
+
+    def text_to_speech(self, text: str, output_file: str, audio_tags: AudioTags):
+        max_chars = 2000
+        text_chunks = split_text(text, max_chars, self.config.language)
+
+        audio_segments = []
+        chunk_ids = []
+
+        for i, chunk in enumerate(text_chunks, 1):
+            chunk_id = f"chapter-{audio_tags.idx}_{audio_tags.title}_chunk_{i}_of_{len(text_chunks)}"
+            logger.info(f"Processing {chunk_id}, length={len(chunk)}")
+            logger.debug(f"Processing {chunk_id}, length={len(chunk)}, text=[{chunk}]")
+
+            payload = {
+                "text": chunk,
+                "language": self.config.language.lower(),
+                "voice_id": int(self.config.voice_name),
+                "speech_model": self.config.model_name,
+                "output_configuration": {"format": self.config.output_format},
+            }
+
+            if self.config.speaking_rate is not None:
+                payload["speaking_rate"] = self.config.speaking_rate
+
+            if (
+                self.config.camb_instructions
+                and self.config.model_name == "mars-instruct"
+            ):
+                payload["user_instructions"] = self.config.camb_instructions
+
+            audio_data = self._call_api_with_retry(payload, chunk_id)
+            audio_segments.append(io.BytesIO(audio_data))
+            chunk_ids.append(chunk_id)
+
+        merge_audio_segments(
+            audio_segments,
+            output_file,
+            self.config.output_format,
+            chunk_ids,
+            self.config.use_pydub_merge,
+        )
+
+        set_audio_tags(output_file, audio_tags)
+
+    def _call_api_with_retry(self, payload: dict, chunk_id: str) -> bytes:
+        url = "https://client.camb.ai/apis/tts-stream"
+        headers = {
+            "x-api-key": self.api_key,
+            "Content-Type": "application/json",
+        }
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                response = requests.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                    stream=True,
+                    timeout=120,
+                )
+                response.raise_for_status()
+
+                audio_data = b""
+                for data in response.iter_content(chunk_size=8192):
+                    if data:
+                        audio_data += data
+
+                logger.debug(
+                    f"CAMB AI response for {chunk_id}: "
+                    f"status={response.status_code}, size={len(audio_data)} bytes"
+                )
+
+                return audio_data
+
+            except requests.exceptions.HTTPError as e:
+                status = e.response.status_code if e.response is not None else None
+                if status in (429, 500, 502, 503, 504) and attempt < MAX_RETRIES - 1:
+                    wait = RETRY_BACKOFF * (2 ** attempt)
+                    logger.warning(
+                        f"CAMB AI: HTTP {status} for {chunk_id}, "
+                        f"retrying in {wait}s (attempt {attempt + 1}/{MAX_RETRIES})"
+                    )
+                    time.sleep(wait)
+                else:
+                    raise
+            except requests.exceptions.ConnectionError as e:
+                if attempt < MAX_RETRIES - 1:
+                    wait = RETRY_BACKOFF * (2 ** attempt)
+                    logger.warning(
+                        f"CAMB AI: Connection error for {chunk_id}, "
+                        f"retrying in {wait}s (attempt {attempt + 1}/{MAX_RETRIES})"
+                    )
+                    time.sleep(wait)
+                else:
+                    raise
+
+    def get_break_string(self):
+        return "   "
+
+    def get_output_file_extension(self):
+        return self.config.output_format
+
+    def estimate_cost(self, total_chars):
+        logger.warning(
+            "CAMB AI: Cost estimation is not available. "
+            "Please check https://camb.ai for current pricing."
+        )
+        return 0

--- a/audiobook_generator/ui/web_ui.py
+++ b/audiobook_generator/ui/web_ui.py
@@ -14,6 +14,8 @@ from audiobook_generator.tts_providers.openai_tts_provider import get_openai_sup
     get_openai_supported_voices, get_openai_instructions_example, get_openai_supported_output_formats
 from audiobook_generator.tts_providers.piper_tts_provider import get_piper_supported_languages, \
     get_piper_supported_voices, get_piper_supported_qualities, get_piper_supported_speakers
+from audiobook_generator.tts_providers.camb_tts_provider import get_camb_supported_models, \
+    get_camb_supported_output_formats
 from audiobook_generator.utils.log_handler import generate_unique_log_path
 from main import main
 
@@ -53,7 +55,8 @@ def process_ui_form(input_file, output_dir, worker_count, log_level, output_text
                     azure_language, azure_voice, azure_output_format, azure_break_duration,
                     edge_language, edge_voice, edge_output_format, proxy, edge_voice_rate, edge_volume, edge_pitch, edge_break_duration,
                     piper_executable_path, piper_docker_image, piper_language, piper_voice, piper_quality, piper_speaker,
-                    piper_noise_scale, piper_noise_w_scale, piper_length_scale, piper_sentence_silence):
+                    piper_noise_scale, piper_noise_w_scale, piper_length_scale, piper_sentence_silence,
+                    camb_model, camb_voice_id, camb_language, camb_output_format, camb_speaking_rate, camb_instructions):
 
     config = GeneralConfig(None)
     config.input_file = input_file.name if hasattr(input_file, 'name') else input_file
@@ -106,6 +109,14 @@ def process_ui_form(input_file, output_dir, worker_count, log_level, output_text
         config.piper_noise_w_scale = piper_noise_w_scale
         config.piper_length_scale = piper_length_scale
         config.piper_sentence_silence = piper_sentence_silence
+    elif selected_tts == "CAMB AI":
+        config.tts = "camb"
+        config.model_name = camb_model
+        config.voice_name = camb_voice_id
+        config.language = camb_language
+        config.output_format = camb_output_format
+        config.speaking_rate = camb_speaking_rate if camb_speaking_rate != 1.0 else None
+        config.camb_instructions = camb_instructions if camb_instructions else None
     else:
         raise ValueError("Unsupported TTS provider selected")
 
@@ -288,6 +299,26 @@ def host_ui(config):
                         with gr.Row(equal_height=True):
                             piper_length_scale = gr.Slider(minimum=0.0, maximum=5.0, step=0.1, label="Audio Length Scale", value=1.0)
                             piper_sentence_silence = gr.Slider(minimum=0.0, maximum=2.0, step=0.1, label="Sentence Silence", value=0.2)
+
+            with gr.Tab("CAMB AI", id="camb_tab_id") as camb_tab:
+                gr.Markdown("It is expected that user configured: `CAMB_API_KEY` in the environment variables. Get your API key at [studio.camb.ai](https://studio.camb.ai).")
+                with gr.Row(equal_height=True):
+                    camb_model = gr.Dropdown(get_camb_supported_models(), label="Speech Model", value="mars-pro",
+                                            interactive=True, info="mars-pro: high-fidelity, mars-flash: low-latency, mars-instruct: instruction-following")
+                    camb_voice_id = gr.Textbox(label="Voice ID", value="147320", interactive=True,
+                                              info="Numeric voice ID. Browse voices at studio.camb.ai")
+                    camb_language = gr.Textbox(label="Language", value="en-us", interactive=True,
+                                             info="BCP-47 language code (e.g. en-us, es-es, fr-fr)")
+                    camb_output_format = gr.Dropdown(get_camb_supported_output_formats(), label="Output Format",
+                                                    value="mp3", interactive=True)
+                with gr.Row(equal_height=True):
+                    camb_speaking_rate = gr.Slider(minimum=0.5, maximum=2.0, step=0.1, label="Speaking Rate", value=1.0,
+                                                  info="Adjust speed of speech output")
+                with gr.Row(equal_height=True):
+                    camb_instructions = gr.TextArea(label="Instructions (mars-instruct only)", interactive=True, lines=3,
+                                                   placeholder="e.g. Warm, clear, and conversational tone")
+                camb_tab.select(on_tab_change, inputs=None, outputs=None)
+
         gr.Markdown("---")
         with gr.Row(equal_height=True):
             gr.Button("Stop").click(
@@ -303,7 +334,8 @@ def host_ui(config):
                     azure_language, azure_voice, azure_output_format, azure_break_duration,
                     edge_language, edge_voice, edge_output_format, proxy, edge_voice_rate, edge_volume, edge_pitch, edge_break_duration,
                     piper_executable_path, piper_docker_image, piper_language, piper_voice, piper_quality, piper_speaker,
-                    piper_noise_scale, piper_noise_w_scale, piper_length_scale, piper_sentence_silence
+                    piper_noise_scale, piper_noise_w_scale, piper_length_scale, piper_sentence_silence,
+                    camb_model, camb_voice_id, camb_language, camb_output_format, camb_speaking_rate, camb_instructions
                 ],
                 outputs=None)
         with gr.Row():

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def handle_args():
         "--tts",
         choices=get_supported_tts_providers(),
         default=get_supported_tts_providers()[0],
-        help="Choose TTS provider (default: azure). azure: Azure Cognitive Services, openai: OpenAI TTS API. When using azure, environment variables MS_TTS_KEY and MS_TTS_REGION must be set. When using openai, environment variable OPENAI_API_KEY must be set.",
+        help="Choose TTS provider (default: azure). azure: Azure Cognitive Services, openai: OpenAI TTS API, edge: Microsoft Edge Read Aloud, piper: Piper local TTS, camb: CAMB AI TTS. When using azure, set MS_TTS_KEY and MS_TTS_REGION. When using openai, set OPENAI_API_KEY. When using camb, set CAMB_API_KEY.",
     )
     parser.add_argument(
         "--log",
@@ -201,6 +201,19 @@ def handle_args():
         "--piper_length_scale",
         default=1.0,
         help="Phoneme length, a.k.a. speaking rate",
+    )
+
+    camb_tts_group = parser.add_argument_group(title="camb specific")
+    camb_tts_group.add_argument(
+        "--speaking_rate",
+        default=None,
+        type=float,
+        help="Speaking rate for CAMB AI TTS. Adjusts the speed of speech output.",
+    )
+    camb_tts_group.add_argument(
+        "--camb_instructions",
+        default=None,
+        help="User instructions for CAMB AI TTS (style/tone guidance). Only supported with 'mars-instruct' model.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Summary

Hi there! We're the team at [CAMB AI](https://camb.ai), a speech and localization engine trusted by brands like the Premier League, the NBA, NASCAR, and the Australian Open.

We'd love to be included as a TTS provider option in this project. This PR adds CAMB AI as a 5th TTS provider alongside Azure, OpenAI, Edge, and Piper.

### What's included

- New `CambTTSProvider` class using the CAMB AI streaming TTS API
- Support for 3 speech models: `mars-pro` (high-fidelity), `mars-flash` (low-latency), and `mars-instruct` (instruction-following)
- 140+ languages supported
- Output in MP3, WAV, or FLAC
- Configurable voice ID, speaking rate, and style instructions (mars-instruct)
- CLI arguments (`--speaking_rate`, `--camb_instructions`)
- Full Gradio WebUI tab integration
- No new dependencies (uses the existing `requests` library)
- Retry with exponential backoff for transient errors

### How to use

```bash
export CAMB_API_KEY=your_key_here
python main.py book.epub output/ --tts camb
```

### Files changed

- `audiobook_generator/tts_providers/camb_tts_provider.py` (new)
- `audiobook_generator/tts_providers/base_tts_provider.py`
- `audiobook_generator/config/general_config.py`
- `main.py`
- `audiobook_generator/ui/web_ui.py`

## Test plan

- [x] `python main.py --tts camb --help` shows CAMB-specific args
- [x] Successfully converted a 3-chapter EPUB to MP3 audiobook files
- [x] Audio plays back correctly with embedded metadata
- [ ] WebUI tab renders and converts successfully